### PR TITLE
🔀 :: (#55) notice list page publishing

### DIFF
--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
@@ -30,9 +30,7 @@ import com.mpersand.gymi_components.theme.IcPlus
 import com.mpersand.gymi_components.theme.IcReservation
 
 @Composable
-fun NoticeListScreen(
-    modifier: Modifier = Modifier
-) {
+fun NoticeListScreen(modifier: Modifier = Modifier) {
     var selected by remember { mutableStateOf(4) }
     Scaffold(
         scaffoldState = rememberScaffoldState(),

--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
@@ -1,0 +1,102 @@
+package com.mpersand.presentation.view.notice.list
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mpersand.gymi_components.component.header.GYMIHeader
+import com.mpersand.gymi_components.component.item.GYMINoticeItem
+import com.mpersand.gymi_components.component.navbar.GYMINavBar
+import com.mpersand.gymi_components.component.navbar.GYMINavItem
+import com.mpersand.gymi_components.theme.GYMITheme
+import com.mpersand.gymi_components.theme.IcEquipment
+import com.mpersand.gymi_components.theme.IcHome
+import com.mpersand.gymi_components.theme.IcPlus
+import com.mpersand.gymi_components.theme.IcReservation
+
+@Composable
+fun NoticeListScreen(
+    modifier: Modifier = Modifier
+) {
+    var selected by remember { mutableStateOf(4) }
+    Scaffold(
+        scaffoldState = rememberScaffoldState(),
+        floatingActionButton = {
+            FloatingActionButton(
+                backgroundColor = GYMITheme.colors.n4,
+                onClick = { /*TODO*/ }
+            ) { IcPlus(tint = GYMITheme.colors.bw) }
+        },
+        isFloatingActionButtonDocked = false,
+        bottomBar = {
+            val navItems = listOf("reservation", "home", "equipment")
+            GYMINavBar {
+                repeat(3) {
+                    GYMINavItem(
+                        selected = selected == it,
+                        icon = {
+                            when (navItems[it]) {
+                                "reservation" -> IcReservation(tint = LocalContentColor.current)
+                                "home" -> IcHome(tint = LocalContentColor.current)
+                                "equipment" -> IcEquipment(tint = LocalContentColor.current)
+                            }
+                        }
+                    ) {
+                        selected = it
+                    }
+                }
+            }
+        }
+    ) { contentPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(GYMITheme.colors.bg)
+                .padding(contentPadding)
+        ) {
+            GYMIHeader(navigateToMain = {}, navigateToNotice = {}, navigationToProfile = {})
+            Spacer(modifier = Modifier.height(35.dp))
+            Column(modifier = modifier.padding(horizontal = 20.dp)) {
+                Text(
+                    text = "공지사항",
+                    style = GYMITheme.typography.h4,
+                    color = GYMITheme.colors.bw
+                )
+                Spacer(modifier = Modifier.height(25.dp))
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(10) {
+                        GYMINoticeItem(
+                            title = "Title 0${it + 1}",
+                            content = "content content content",
+                            date = "2023.09.0${it + 1}"
+                        )
+                        Spacer(modifier = Modifier.height(20.dp))
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun preview() {
+    NoticeListScreen()
+}

--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/list/NoticeListScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mpersand.gymi_components.component.header.GYMIHeader
 import com.mpersand.gymi_components.component.item.GYMINoticeItem
@@ -92,11 +91,4 @@ fun NoticeListScreen(
             }
         }
     }
-
-}
-
-@Preview
-@Composable
-fun preview() {
-    NoticeListScreen()
 }


### PR DESCRIPTION
### 개요
- NoticeListScreen 퍼블리싱 하기

### 작업내용
- NoticeListScreen 퍼블리싱

### 디자인
<img width="400" alt="image" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/6e5168f3-510f-42e7-ae20-29825491c81d">

### 구현화면 (선택)
<img width="400" alt="스크린샷 2023-08-20 오후 5 55 25" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/38ac1762-4c86-4989-a1bf-a6944962eb5f">

### 구현영상 (선택)
https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/973611b2-b96d-41fd-97e7-b5c6ca50dbb3

### 기타사항 (선택)
- bottomBar에 중복된 코드를 계속 사용하니 컴포넌트로 하나 만들어서 사용하면 좋을꺼같다