### PR TITLE
🔀 :: (#66) modifier gymi badminton court for main page

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -29,7 +29,7 @@ object Versions {
 
     const val GSON = "2.8.9"
 
-    const val GUS = "1.1.4"
+    const val GUS = "1.1.6"
 
     const val COIL = "2.4.0"
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/component/BadmintonHalfCourt.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/component/BadmintonHalfCourt.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import com.mpersand.gymi_components.component.court.GYMIBadmintonCourt
 
@@ -16,11 +17,22 @@ fun ColumnScope.BadmintonHalfCourt(
     onClick: () -> Unit
 ) {
     repeat(2) {
-        GYMIBadmintonCourt(
-            modifier = modifier.fillMaxWidth(),
-            isReserved = isReserved,
-            onClick = onClick
-        )
-        Spacer(modifier = Modifier.height(2.dp))
+        if (it == 0) {
+            GYMIBadmintonCourt(
+                modifier = modifier.fillMaxWidth(),
+                isReserved = isReserved,
+                onClick = onClick
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+        } else {
+            GYMIBadmintonCourt(
+                modifier = modifier
+                    .fillMaxWidth()
+                    .graphicsLayer { rotationX = 180f },
+                isReserved = isReserved,
+                onClick = onClick
+            )
+            Spacer(modifier = Modifier.height(5.dp))
+        }
     }
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
@@ -61,18 +61,19 @@ fun MainScreen(
                     }
                 }
                 "화", "목" -> {
-                    repeat(2) {
+                    repeat(4) {
                         BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
                     }
                 }
                 "금" -> {
-                    BasketballHalfCourt(modifier = Modifier.weight(2f)) {}
-                    Spacer(modifier = Modifier.height(2.dp))
-                    BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
+                    BasketballHalfCourt(modifier = Modifier.weight(4f)) {}
+                    Spacer(modifier = Modifier.height(5.dp))
+                    repeat(2) {
+                        BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(30.dp))
             val navItems = listOf("reservation", "home", "equipment")
             GYMINavBar {
                 repeat(3) {

--- a/presentation/src/main/java/com/mpersand/presentation/view/reservation/ReservationScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/reservation/ReservationScreen.kt
@@ -61,15 +61,17 @@ fun ReservationScreen(
                 }
 
                 "화", "목" -> {
-                    repeat(2) {
+                    repeat(4) {
                         BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
                     }
                 }
 
                 "금" -> {
-                    BasketballHalfCourt(modifier = Modifier.weight(2f)) {}
-                    Spacer(modifier = Modifier.height(2.dp))
-                    BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
+                    BasketballHalfCourt(modifier = Modifier.weight(4f)) {}
+                    Spacer(modifier = Modifier.height(5.dp))
+                    repeat(2) {
+                        BadmintonHalfCourt(modifier = Modifier.weight(1f)) {}
+                    }
                 }
             }
         }


### PR DESCRIPTION
### 개요
- 바뀐 GUS(GYMIBadmintonCourt)에 맞춰서 리펙토링

### 작업내용
- GUS 버전 올리기
- BadmintonHalfCourt, MainScreen, ReservationScreen 리펙토링

### 구현화면 (선택)
<img width="400" alt="스크린샷 2023-08-22 오전 11 22 37" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/f1663fe6-b855-4ee9-b01e-6debd1a3c769">
<img width="400" alt="스크린샷 2023-08-22 오전 11 32 44" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/98c9b040-09eb-4742-ae56-b5371f51fe4f">
<img width="400" alt="스크린샷 2023-08-22 오전 11 26 27" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/fa128b2b-834f-4c46-9b5f-aaf0f12477c6">
<img width="400" alt="스크린샷 2023-08-22 오전 11 32 51" src="https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/0b0cf08e-c4b2-4771-9f32-2da63d759a98">

### 구현영상 (선택)
https://github.com/Team-Ampersand/GYMI-Android/assets/84944098/c5ef48b0-8726-4710-b296-68fd39093a4f

### 기타사항 (선택)
- 원래는 MainScreen만 먼저 할려했는데 다 해버렸습니다