### PR TITLE
🔀 :: (#72) set gymi theme light or dark

### DIFF
--- a/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
@@ -96,7 +96,7 @@ class MainActivity : ComponentActivity() {
                             .padding(paddingValues)
                             .background(GYMITheme.colors.bg),
                         navController = navController,
-                        startDestination = mainRoute
+                        startDestination = loginRoute
                     )
                 }
             }

--- a/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
@@ -3,6 +3,7 @@ package com.mpersand.gymi_android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.FloatingActionButton
@@ -20,6 +21,7 @@ import com.mpersand.gymi_components.theme.IcEquipment
 import com.mpersand.gymi_components.theme.IcHome
 import com.mpersand.gymi_components.theme.IcPlus
 import com.mpersand.gymi_components.theme.IcReservation
+import com.mpersand.gymi_components.theme.Theme
 import com.mpersand.presentation.view.equipment.navigation.equipmentRoute
 import com.mpersand.presentation.view.login.navigation.loginRoute
 import com.mpersand.presentation.view.main.navigation.mainRoute
@@ -35,6 +37,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            GYMITheme.gymiTheme = if (!isSystemInDarkTheme()) Theme.LIGHT else Theme.DARK
+
             GYMITheme {
                 val navController = rememberNavController()
                 val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
@@ -3,6 +3,7 @@ package com.mpersand.gymi_android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -91,9 +92,11 @@ class MainActivity : ComponentActivity() {
                     }
                 ) { paddingValues ->
                     GYMINavHost(
-                        modifier = Modifier.padding(paddingValues),
+                        modifier = Modifier
+                            .padding(paddingValues)
+                            .background(GYMITheme.colors.bg),
                         navController = navController,
-                        startDestination = loginRoute
+                        startDestination = mainRoute
                     )
                 }
             }

--- a/presentation/src/main/java/com/mpersand/presentation/view/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/login/LoginScreen.kt
@@ -1,6 +1,5 @@
 package com.mpersand.presentation.view.login
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,9 +20,7 @@ import com.msg.gauthsignin.component.utils.Types
 @Composable
 fun LoginScreen(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(GYMITheme.colors.bg),
+        modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Spacer(modifier = modifier.weight(1f))

--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/detail/NoticeDetailScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/detail/NoticeDetailScreen.kt
@@ -40,7 +40,6 @@ fun NoticeDetailScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(GYMITheme.colors.bg)
             .padding(horizontal = 20.dp)
     ) {
         Spacer(modifier = Modifier.height(13.dp))

--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/edit/NoticeEditScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/edit/NoticeEditScreen.kt
@@ -47,7 +47,6 @@ fun NoticeEditScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(GYMITheme.colors.bg)
             .padding(horizontal = 20.dp)
     ) {
         Spacer(modifier = Modifier.height(13.dp))

--- a/presentation/src/main/java/com/mpersand/presentation/view/notice/empty/NoticeEmptyScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/notice/empty/NoticeEmptyScreen.kt
@@ -1,6 +1,5 @@
 package com.mpersand.presentation.view.notice.empty
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -19,9 +18,7 @@ import com.mpersand.gymi_components.theme.IcNotice
 @Composable
 fun NoticeEmptyScreen(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(GYMITheme.colors.bg),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {


### PR DESCRIPTION
### 개요
- GYMITheme Light/Dark 설정

### 작업내용
- System Theme에 맞게 GYMITheme 설정
- Background Color를 최상위 컴포저블에서 설정 및 중복 코드 삭제