### PR TITLE
🔀 :: (#74) write navigation backstack logic

### DIFF
--- a/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.mpersand.gymi_android.navigation.GYMINavHost
 import com.mpersand.gymi_android.navigation.navigateToDestination
 import com.mpersand.gymi_components.component.header.GYMIHeader
 import com.mpersand.gymi_components.component.navbar.GYMINavBar
@@ -95,7 +96,7 @@ class MainActivity : ComponentActivity() {
                             .padding(paddingValues)
                             .background(GYMITheme.colors.bg),
                         navController = navController,
-                        startDestination = mainRoute
+                        startDestination = loginRoute
                     )
                 }
             }

--- a/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.mpersand.gymi_android.navigation.navigateToDestination
 import com.mpersand.gymi_components.component.header.GYMIHeader
 import com.mpersand.gymi_components.component.navbar.GYMINavBar
 import com.mpersand.gymi_components.component.navbar.GYMINavItem
@@ -26,11 +27,9 @@ import com.mpersand.gymi_components.theme.Theme
 import com.mpersand.presentation.view.equipment.navigation.equipmentRoute
 import com.mpersand.presentation.view.login.navigation.loginRoute
 import com.mpersand.presentation.view.main.navigation.mainRoute
-import com.mpersand.presentation.view.main.navigation.navigateToMain
-import com.mpersand.presentation.view.notice.list.navigation.navigateToNoticeList
 import com.mpersand.presentation.view.notice.list.navigation.noticeListRoute
 import com.mpersand.presentation.view.notice.write.navigation.navigateToNoticeWrite
-import com.mpersand.presentation.view.profile.navigation.navigateToProfile
+import com.mpersand.presentation.view.profile.navigation.profileRoute
 import com.mpersand.presentation.view.reservation.navigation.reservationRoute
 
 class MainActivity : ComponentActivity() {
@@ -50,9 +49,9 @@ class MainActivity : ComponentActivity() {
                     topBar = {
                         if (currentRoute != loginRoute) {
                             GYMIHeader(
-                                navigateToMain = { navController.navigateToMain() },
-                                navigateToNotice = { navController.navigateToNoticeList() },
-                                navigationToProfile = { navController.navigateToProfile() }
+                                navigateToMain = { navController.navigateToDestination(mainRoute) },
+                                navigateToNotice = { navController.navigateToDestination(noticeListRoute) },
+                                navigationToProfile = { navController.navigateToDestination(profileRoute) }
                             )
                         }
                     },
@@ -74,7 +73,7 @@ class MainActivity : ComponentActivity() {
                                             }
                                         }
                                     ) {
-                                        navController.navigate(destination)
+                                        navController.navigateToDestination(destination)
                                     }
                                 }
                             }
@@ -96,7 +95,7 @@ class MainActivity : ComponentActivity() {
                             .padding(paddingValues)
                             .background(GYMITheme.colors.bg),
                         navController = navController,
-                        startDestination = loginRoute
+                        startDestination = mainRoute
                     )
                 }
             }

--- a/app/src/main/java/com/mpersand/gymi_android/navigation/GYMINavHost.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/navigation/GYMINavHost.kt
@@ -1,4 +1,4 @@
-package com.mpersand.gymi_android
+package com.mpersand.gymi_android.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/mpersand/gymi_android/navigation/GYMINavigation.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/navigation/GYMINavigation.kt
@@ -1,0 +1,14 @@
+package com.mpersand.gymi_android.navigation
+
+import androidx.navigation.NavController
+
+fun NavController.navigateToDestination(route: String) {
+    val startRoute = this.graph.startDestinationRoute
+
+    this.navigate(route) {
+        startRoute?.let {
+            popUpTo(it)
+        }
+        launchSingleTop = true
+    }
+}

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/navigation/MainNavigation.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/navigation/MainNavigation.kt
@@ -3,12 +3,17 @@ package com.mpersand.presentation.view.main.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.mpersand.presentation.view.login.navigation.loginRoute
 import com.mpersand.presentation.view.main.MainScreen
 
 const val mainRoute = "main_route"
 
 fun NavController.navigateToMain() {
-    this.navigate(mainRoute)
+    this.navigate(mainRoute) {
+        popUpTo(loginRoute) {
+            inclusive = true
+        }
+    }
 }
 
 fun NavGraphBuilder.mainScreen() {


### PR DESCRIPTION
### 개요
- TopBar & BottomBar에서 이동시 BackStack 중복 처리, 로그인 이후 LoginScreen BackStack에서 삭제

### 작업내용
- TopBar & BottomBar 이동시 중복으로 BackStack에 쌓이지 않도록 처리
- 로그인 후 MainScreen으로 이동시 LoginScreen을 popUp