### PR TITLE
🔀 :: (#118) write notice domain logic

### DIFF
--- a/app/src/main/java/com/mpersand/gymi_android/module/RepositoryModule.kt
+++ b/app/src/main/java/com/mpersand/gymi_android/module/RepositoryModule.kt
@@ -2,8 +2,10 @@ package com.mpersand.gymi_android.module
 
 import com.mpersand.data.repository.AuthRepositoryImpl
 import com.mpersand.data.repository.DeclarationRepositoryImpl
+import com.mpersand.data.repository.NoticeRepositoryImpl
 import com.mpersand.domain.repository.AuthRepository
 import com.mpersand.domain.repository.DeclarationRepository
+import com.mpersand.domain.repository.NoticeRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,7 @@ interface RepositoryModule {
 
     @Binds
     fun bindsDeclarationRepository(declarationRepositoryImpl: DeclarationRepositoryImpl): DeclarationRepository
+
+    @Binds
+    fun bindsNoticeRepository(noticeRepositoryImpl: NoticeRepositoryImpl): NoticeRepository
 }

--- a/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeDetailResponse.kt
+++ b/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.mpersand.data.remote.model.notice.response
 
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
 import com.squareup.moshi.JsonClass
 import java.time.LocalDateTime
 
@@ -11,4 +12,13 @@ data class NoticeDetailResponse(
     val role: String,
     val noticeFile: List<NoticeFile>,
     val createdDate: LocalDateTime
+)
+
+fun NoticeDetailResponse.asNoticeDetailResponseModel() = NoticeDetailResponseModel(
+    id = id,
+    title = title,
+    content = content,
+    role = role,
+    noticeFile = noticeFile.map { it.asNoticeFileModel() },
+    createdDate = createdDate
 )

--- a/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeFile.kt
+++ b/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeFile.kt
@@ -1,9 +1,15 @@
 package com.mpersand.data.remote.model.notice.response
 
+import com.mpersand.domain.model.notice.response.NoticeFileModel
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class NoticeFile(
     val id: Long,
     val url: String
+)
+
+fun NoticeFile.asNoticeFileModel() = NoticeFileModel(
+    id = id,
+    url = url
 )

--- a/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeResponse.kt
+++ b/data/src/main/java/com/mpersand/data/remote/model/notice/response/NoticeResponse.kt
@@ -1,5 +1,6 @@
 package com.mpersand.data.remote.model.notice.response
 
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
 import com.squareup.moshi.JsonClass
 import java.time.LocalDateTime
 
@@ -10,4 +11,12 @@ data class NoticeResponse(
     val content: String,
     val role: String,
     val createdDate: LocalDateTime
+)
+
+fun NoticeResponse.asNoticeResponseModel() = NoticeResponseModel(
+    id = id,
+    title = title,
+    content = content,
+    role = role,
+    createdDate = createdDate
 )

--- a/data/src/main/java/com/mpersand/data/repository/NoticeRepositoryImpl.kt
+++ b/data/src/main/java/com/mpersand/data/repository/NoticeRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.mpersand.data.repository
+
+import com.mpersand.data.remote.datasource.notice.NoticeDataSource
+import com.mpersand.data.remote.model.notice.response.asNoticeDetailResponseModel
+import com.mpersand.data.remote.model.notice.response.asNoticeResponseModel
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.NoticeRepository
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import javax.inject.Inject
+
+class NoticeRepositoryImpl @Inject constructor(
+    private val noticeDataSource: NoticeDataSource
+): NoticeRepository {
+    override suspend fun createNotice(
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) = noticeDataSource.createNotice(notice, file)
+
+    override suspend fun deleteNotice(id: Long) = noticeDataSource.deleteNotice(id)
+
+    override suspend fun modifyNotice(
+        id: Long,
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) = noticeDataSource.modifyNotice(id, notice, file)
+
+    override suspend fun getAllNotice(): List<NoticeResponseModel> = noticeDataSource.getAllNotice().map { it.asNoticeResponseModel() }
+
+    override suspend fun getDetailNotice(id: Long): NoticeDetailResponseModel = noticeDataSource.getDetailNotice(id).asNoticeDetailResponseModel()
+}

--- a/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
+++ b/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
@@ -69,7 +69,7 @@ class NoticeDataSourceTest : BehaviorSpec() {
                 )
                 Then("공지사항이 수정된다") {
                     val modifiedNotice = dataSource.getAllNotice()
-                    modifiedNotice.single { it.id == 1L }.title shouldBe "modifiedTitle"
+                    modifiedNotice.single { it.id == 1L }.title shouldBe "modified title"
                 }
             }
         }

--- a/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
+++ b/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
@@ -41,7 +41,6 @@ class NoticeDataSourceTest : BehaviorSpec() {
                 dataSource.deleteNotice(2)
                 Then("공지사항이 삭제된다") {
                     dataSource.getAllNotice().size shouldBe 1
-                    println(dataSource.getAllNotice())
                 }
             }
 

--- a/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
+++ b/data/src/test/java/com/mpersand/data/remote/datasource/notice/NoticeDataSourceTest.kt
@@ -41,6 +41,7 @@ class NoticeDataSourceTest : BehaviorSpec() {
                 dataSource.deleteNotice(2)
                 Then("공지사항이 삭제된다") {
                     dataSource.getAllNotice().size shouldBe 1
+                    println(dataSource.getAllNotice())
                 }
             }
 
@@ -59,8 +60,8 @@ class NoticeDataSourceTest : BehaviorSpec() {
             }
 
             When("공지사항을 수정한다") {
-                val modifiedTitle = "modified title"
                 noticeMap["title"] = "modified title".toRequestBody("text/plain".toMediaType())
+                noticeMap["content"] = "modified content".toRequestBody("text/plain".toMediaType())
                 dataSource.modifyNotice(
                     id = 1,
                     notice = noticeMap,
@@ -68,7 +69,7 @@ class NoticeDataSourceTest : BehaviorSpec() {
                 )
                 Then("공지사항이 수정된다") {
                     val modifiedNotice = dataSource.getAllNotice()
-                    modifiedNotice.single { it.id == 1L }.title shouldBe modifiedTitle
+                    modifiedNotice.single { it.id == 1L }.title shouldBe "modifiedTitle"
                 }
             }
         }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -49,4 +49,6 @@ dependencies {
     testImplementation(libs.libraries.kotest)
     androidTestImplementation(libs.test.android.junit)
     androidTestImplementation(libs.test.espresso)
+
+    implementation(libs.libraries.okhttp)
 }

--- a/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeDetailResponseModel.kt
+++ b/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeDetailResponseModel.kt
@@ -1,0 +1,12 @@
+package com.mpersand.domain.model.notice.response
+
+import java.time.LocalDateTime
+
+data class NoticeDetailResponseModel(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val role: String,
+    val noticeFile: List<NoticeFileModel>,
+    val createdDate: LocalDateTime
+)

--- a/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeFileModel.kt
+++ b/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeFileModel.kt
@@ -1,0 +1,6 @@
+package com.mpersand.domain.model.notice.response
+
+data class NoticeFileModel(
+    val id: Long,
+    val url: String
+)

--- a/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeResponseModel.kt
+++ b/domain/src/main/java/com/mpersand/domain/model/notice/response/NoticeResponseModel.kt
@@ -1,0 +1,11 @@
+package com.mpersand.domain.model.notice.response
+
+import java.time.LocalDateTime
+
+data class NoticeResponseModel(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val role: String,
+    val createdDate: LocalDateTime
+)

--- a/domain/src/main/java/com/mpersand/domain/repository/NoticeRepository.kt
+++ b/domain/src/main/java/com/mpersand/domain/repository/NoticeRepository.kt
@@ -1,0 +1,25 @@
+package com.mpersand.domain.repository
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+
+interface NoticeRepository {
+    suspend fun createNotice(
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    )
+
+    suspend fun deleteNotice(id: Long)
+
+    suspend fun modifyNotice(
+        id: Long,
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    )
+
+    suspend fun getAllNotice(): List<NoticeResponseModel>
+
+    suspend fun getDetailNotice(id: Long): NoticeDetailResponseModel
+}

--- a/domain/src/main/java/com/mpersand/domain/usecase/notice/CreateNoticeUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/notice/CreateNoticeUseCase.kt
@@ -1,0 +1,15 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.repository.NoticeRepository
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import javax.inject.Inject
+
+class CreateNoticeUseCase @Inject constructor(
+    private val noticeRepository: NoticeRepository
+) {
+    suspend operator fun invoke(
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) = kotlin.runCatching { noticeRepository.createNotice(notice, file) }
+}

--- a/domain/src/main/java/com/mpersand/domain/usecase/notice/DeleteNoticeUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/notice/DeleteNoticeUseCase.kt
@@ -1,0 +1,10 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.repository.NoticeRepository
+import javax.inject.Inject
+
+class DeleteNoticeUseCase @Inject constructor(
+    private val noticeRepository: NoticeRepository
+) {
+    suspend operator fun invoke(id: Long) = kotlin.runCatching { noticeRepository.deleteNotice(id) }
+}

--- a/domain/src/main/java/com/mpersand/domain/usecase/notice/GetAllNoticeUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/notice/GetAllNoticeUseCase.kt
@@ -1,0 +1,10 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.repository.NoticeRepository
+import javax.inject.Inject
+
+class GetAllNoticeUseCase @Inject constructor(
+    private val noticeRepository: NoticeRepository
+) {
+    suspend operator fun invoke() = kotlin.runCatching { noticeRepository.getAllNotice() }
+}

--- a/domain/src/main/java/com/mpersand/domain/usecase/notice/GetDetailNoticeUsecase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/notice/GetDetailNoticeUsecase.kt
@@ -1,0 +1,10 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.repository.NoticeRepository
+import javax.inject.Inject
+
+class GetDetailNoticeUsecase @Inject constructor(
+    private val noticeRepository: NoticeRepository
+) {
+    suspend operator fun invoke(id: Long) = kotlin.runCatching { noticeRepository.getDetailNotice(id) }
+}

--- a/domain/src/main/java/com/mpersand/domain/usecase/notice/ModifyNoticeUseCase.kt
+++ b/domain/src/main/java/com/mpersand/domain/usecase/notice/ModifyNoticeUseCase.kt
@@ -1,0 +1,16 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.repository.NoticeRepository
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import javax.inject.Inject
+
+class ModifyNoticeUseCase @Inject constructor(
+  private val noticeRepository: NoticeRepository
+) {
+    suspend operator fun invoke(
+        id: Long,
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) = kotlin.runCatching { noticeRepository.modifyNotice(id, notice, file) }
+}

--- a/domain/src/test/java/com/mpersand/domain/repository/FakeNoticeRepository.kt
+++ b/domain/src/test/java/com/mpersand/domain/repository/FakeNoticeRepository.kt
@@ -1,0 +1,59 @@
+package com.mpersand.domain.repository
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okio.Buffer
+import java.time.LocalDateTime
+
+class FakeNoticeRepository(
+    private var noticesResponses: List<NoticeResponseModel>,
+    private val noticeDetailResponses: NoticeDetailResponseModel,
+): NoticeRepository {
+    override suspend fun createNotice(
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) {
+        noticesResponses = noticesResponses.plus(
+            NoticeResponseModel(
+                id = noticesResponses.size.toLong() + 1,
+                title = notice["title"]!!.requestBodyToString(),
+                content =  notice["content"]!!.requestBodyToString(),
+                role = "",
+                createdDate = LocalDateTime.now(),
+            )
+        )
+    }
+
+    override suspend fun deleteNotice(id: Long) {
+        noticesResponses = noticesResponses.filterNot { it.id == id }
+    }
+
+    override suspend fun modifyNotice(
+        id: Long,
+        notice: HashMap<String, RequestBody>,
+        file: MultipartBody.Part
+    ) {
+        noticesResponses = noticesResponses.filterNot { it.id == id }
+        noticesResponses = noticesResponses.plus(
+            NoticeResponseModel(
+                id = noticesResponses.size.toLong() + 1,
+                title = notice["title"]!!.requestBodyToString(),
+                content = notice["content"]!!.requestBodyToString(),
+                role = "",
+                createdDate = LocalDateTime.now(),
+            )
+        )
+    }
+
+    override suspend fun getAllNotice(): List<NoticeResponseModel> = noticesResponses
+
+    override suspend fun getDetailNotice(id: Long): NoticeDetailResponseModel = noticeDetailResponses
+}
+
+private fun RequestBody.requestBodyToString(): String {
+    val buffer = Buffer()
+    this.writeTo(buffer)
+    return buffer.readUtf8()
+}

--- a/domain/src/test/java/com/mpersand/domain/usecase/notice/CreateNoticeUseCaseTest.kt
+++ b/domain/src/test/java/com/mpersand/domain/usecase/notice/CreateNoticeUseCaseTest.kt
@@ -1,0 +1,72 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeFileModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.FakeNoticeRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+import java.time.LocalDateTime
+
+class CreateNoticeUseCaseTest : BehaviorSpec() {
+    private val repository = FakeNoticeRepository(noticeResponse, noticeDetailResponse)
+    private val useCase = CreateNoticeUseCase(noticeRepository = repository)
+
+    init {
+        Given("공지사항이 존재한다") {
+            When("공지사항을 작성한다") {
+                noticeMap["title"] = "title".toRequestBody("text/plain".toMediaType())
+                noticeMap["content"] = "content".toRequestBody("text/plain".toMediaType())
+                useCase(
+                    notice = noticeMap,
+                    file = filePart
+                )
+                Then("공지사항이 생성된다") {
+                    repository.getAllNotice().size shouldBe 2
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val noticeResponse = listOf(
+            NoticeResponseModel(
+                id = 1,
+                title = "title 1",
+                content = "content 1",
+                role = "",
+                createdDate = LocalDateTime.now()
+            )
+        )
+
+
+        private val noticeDetailResponse = NoticeDetailResponseModel(
+            id = 1,
+            title = "title 1",
+            content = "content 1",
+            role = "",
+            noticeFile = listOf(
+                NoticeFileModel(
+                    id = 1,
+                    url = ""
+                )
+            ),
+            createdDate = LocalDateTime.now()
+        )
+
+        private var noticeMap = HashMap<String, RequestBody>()
+
+        private val file = File("")
+        private val filePart = MultipartBody.Part.createFormData(
+            "file",
+            file.name,
+            file.asRequestBody("multipart/form-data".toMediaType())
+        )
+    }
+}

--- a/domain/src/test/java/com/mpersand/domain/usecase/notice/DeleteNoticeUseCaseTest.kt
+++ b/domain/src/test/java/com/mpersand/domain/usecase/notice/DeleteNoticeUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeFileModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.FakeNoticeRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class DeleteNoticeUseCaseTest : BehaviorSpec() {
+    private val repository = FakeNoticeRepository(noticeResponse, noticeDetailResponse)
+    private val useCase = DeleteNoticeUseCase(noticeRepository = repository)
+
+    init {
+        Given("공지사항이 존재한다") {
+            When("공지사항을 삭제한다") {
+                useCase(2)
+                Then("공지사항이 삭제된다") {
+                    repository.getAllNotice().size shouldBe 1
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val noticeResponse = listOf(
+            NoticeResponseModel(
+                id = 1,
+                title = "title 1",
+                content = "content 1",
+                role = "",
+                createdDate = LocalDateTime.now()
+            ),
+            NoticeResponseModel(
+                id = 2,
+                title = "title 2",
+                content = "content 2",
+                role = "",
+                createdDate = LocalDateTime.now()
+            )
+        )
+
+
+        private val noticeDetailResponse = NoticeDetailResponseModel(
+            id = 1,
+            title = "title 1",
+            content = "content 1",
+            role = "",
+            noticeFile = listOf(
+                NoticeFileModel(
+                    id = 1,
+                    url = ""
+                )
+            ),
+            createdDate = LocalDateTime.now()
+        )
+    }
+}

--- a/domain/src/test/java/com/mpersand/domain/usecase/notice/GetAllNoticeUseCaseTest.kt
+++ b/domain/src/test/java/com/mpersand/domain/usecase/notice/GetAllNoticeUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeFileModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.FakeNoticeRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class GetAllNoticeUseCaseTest : BehaviorSpec() {
+    private val repository = FakeNoticeRepository(noticeResponse, noticeDetailResponse)
+    private val useCase = GetAllNoticeUseCase(noticeRepository = repository)
+
+    init {
+        Given("공지사항이 존재한다") {
+            val expected = noticeResponse
+            When("공지사항을 모두 가져온다") {
+                val notice = useCase().getOrNull()
+                Then("공지사항 리스트를 반환한다") {
+                    notice shouldBe expected
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val noticeResponse = listOf(
+            NoticeResponseModel(
+                id = 1,
+                title = "title 1",
+                content = "content 1",
+                role = "",
+                createdDate = LocalDateTime.now()
+            )
+        )
+
+
+        private val noticeDetailResponse = NoticeDetailResponseModel(
+            id = 1,
+            title = "title 1",
+            content = "content 1",
+            role = "",
+            noticeFile = listOf(
+                NoticeFileModel(
+                    id = 1,
+                    url = ""
+                )
+            ),
+            createdDate = LocalDateTime.now()
+        )
+    }
+}

--- a/domain/src/test/java/com/mpersand/domain/usecase/notice/GetDetailNoticeUseCaseTest.kt
+++ b/domain/src/test/java/com/mpersand/domain/usecase/notice/GetDetailNoticeUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeFileModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.FakeNoticeRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class GetDetailNoticeUseCaseTest : BehaviorSpec() {
+    private val repository = FakeNoticeRepository(noticeResponse, noticeDetailResponse)
+    private val useCase = GetDetailNoticeUsecase(noticeRepository = repository)
+
+    init {
+        Given("공지사항이 존재한다") {
+            val expected = noticeDetailResponse
+            When("원하는 공지사항 상세정보를 가져온다") {
+                val notice = useCase(1).getOrNull()
+                Then("원하는 공지사항 상세정보를 반환한다") {
+                    notice shouldBe expected
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val noticeResponse = listOf(
+            NoticeResponseModel(
+                id = 1,
+                title = "title 1",
+                content = "content 1",
+                role = "",
+                createdDate = LocalDateTime.now()
+            )
+        )
+
+
+        private val noticeDetailResponse = NoticeDetailResponseModel(
+            id = 1,
+            title = "title 1",
+            content = "content 1",
+            role = "",
+            noticeFile = listOf(
+                NoticeFileModel(
+                    id = 1,
+                    url = ""
+                )
+            ),
+            createdDate = LocalDateTime.now()
+        )
+    }
+}

--- a/domain/src/test/java/com/mpersand/domain/usecase/notice/ModifyNoticeUseCaseTest.kt
+++ b/domain/src/test/java/com/mpersand/domain/usecase/notice/ModifyNoticeUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.mpersand.domain.usecase.notice
+
+import com.mpersand.domain.model.notice.response.NoticeDetailResponseModel
+import com.mpersand.domain.model.notice.response.NoticeFileModel
+import com.mpersand.domain.model.notice.response.NoticeResponseModel
+import com.mpersand.domain.repository.FakeNoticeRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+import java.time.LocalDateTime
+
+class ModifyNoticeUseCaseTest : BehaviorSpec() {
+    private val repository = FakeNoticeRepository(noticeResponse, noticeDetailResponse)
+    private val useCase = ModifyNoticeUseCase(noticeRepository = repository)
+
+    init {
+        Given("공지사항이 존재한다") {
+            println(repository.getAllNotice())
+            When("공지사항을 수정한다") {
+                noticeMap["title"] = "modifiedTitle".toRequestBody("text/plain".toMediaType())
+                noticeMap["content"] = "modified content".toRequestBody("text/plain".toMediaType())
+                useCase(
+                    id = 1,
+                    notice = noticeMap,
+                    file = filePart
+                )
+                println(repository.getAllNotice())
+                Then("공지사항이 수정된다") {
+                    val modifiedNotice = repository.getAllNotice()
+                    modifiedNotice.single { it.id == 1L }.title shouldBe "modifiedTitle"
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val noticeResponse = listOf(
+            NoticeResponseModel(
+                id = 1,
+                title = "title 1",
+                content = "content 1",
+                role = "",
+                createdDate = LocalDateTime.now()
+            )
+        )
+
+
+        private val noticeDetailResponse = NoticeDetailResponseModel(
+            id = 1,
+            title = "title 1",
+            content = "content 1",
+            role = "",
+            noticeFile = listOf(
+                NoticeFileModel(
+                    id = 1,
+                    url = ""
+                )
+            ),
+            createdDate = LocalDateTime.now()
+        )
+
+        private var noticeMap = HashMap<String, RequestBody>()
+
+        private val file = File("")
+        private val filePart = MultipartBody.Part.createFormData(
+            "file",
+            file.name,
+            file.asRequestBody("multipart/form-data".toMediaType())
+        )
+    }
+}


### PR DESCRIPTION
### 개요
- notice domain 로직 작성

### 작업내용
- model(+ mapper) 생성
- repository 생성
- usecase 생성
- di 세팅
- testcode 구현